### PR TITLE
Use node alpine image as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
-FROM node:carbon
+FROM node:8-alpine
 
 # Change ownership of the global node modules directory
 # to allow installs without requiring sudo privileges.
 #
 # See: https://docs.npmjs.com/getting-started/fixing-npm-permissions
-RUN ["bash", "-c", "chown -R node $(npm config get prefix)/{lib/node_modules,bin,share}"]
+RUN chown -R node $(npm config get prefix)
 
-# Install Google Chrome to support testing
-# See: https://www.ubuntuupdates.org/ppa/google_chrome?dist=stable
-ARG CHROME_VERSION
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list && \
-    apt-get -qqy update && \
-    apt-get -qqy install google-chrome-stable=$CHROME_VERSION
+# Install Chromium
+ARG CHROMIUM_VERSION
+USER root
+RUN apk add --no-cache \
+  --repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
+  chromium=$CHROMIUM_VERSION \
+  chromium-chromedriver=$CHROMIUM_VERSION
+ENV CHROME_BIN=/usr/bin/chromium-browser \
+    CHROME_PATH=/usr/lib/chromium
 
 # Install Angular CLI
 ARG NG_CLI_VERSION

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ in a container.
     browsers: ['customChrome'],
     customLaunchers: {
       customChrome: {
-        base: 'ChromeHeadless',
+        base: 'ChromiumHeadless',
         flags: ['--headless', '--no-sandbox']
       }
     }
@@ -47,6 +47,7 @@ in a container.
 5. Modify `protractor.conf.js` to use headless Chrome:
 
     ```js
+    chromeDriver: '/usr/bin/chromedriver',
     capabilities: {
     'browserName': 'chrome',
       chromeOptions: {
@@ -59,8 +60,6 @@ in a container.
 
     ```json
     "e2e": "ng e2e --webdriver-update=false",
-    "postinstall": "npm run webdriver-manager update -- --versions.standalone=2.53.1 --versions.chrome=2.38 --versions.gecko=v0.13.0",
-    "webdriver-manager": "npm explore protractor -- webdriver-manager"
     ```
 
 ### Development Workflow

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,9 @@
 NG_CLI_VERSION="6.1.5"
-CHROME_VERSION="65.0.3325.181-1"
+CHROMIUM_VERSION="68.0.3440.106-r0"
 
 docker build \
   --build-arg NG_CLI_VERSION=$NG_CLI_VERSION \
-  --build-arg CHROME_VERSION=$CHROME_VERSION \
+  --build-arg CHROMIUM_VERSION=$CHROMIUM_VERSION \
   -t samherrmann/angular-cli .
 
 docker tag samherrmann/angular-cli samherrmann/angular-cli:$NG_CLI_VERSION


### PR DESCRIPTION
This updates the base image used to node:8-alpine. By moving to alpine, we must also use the chromedriver provided by alpine.